### PR TITLE
Fix things up

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ inputs.alertmanager-ntfy.url = "github:pinpox/alertmanager-ntfy";
 
 # Import the module in your configuration.nix
 imports = [
-	self.inputs.alertmanager-ntfy.nixosModules.alertmanager-ntfy
+	self.inputs.alertmanager-ntfy.nixosModules.default
 ];
 
 # Enable and set options

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ with import <nixpkgs>{};
     version = "0.1";
 
 src = ./.;
-    vendorSha256 = "sha256-k45e6RSIl3AQdOFQysIwJP9nlYsSFeaUznVIXfbYwLA=";
+    vendorHash = "sha256-k45e6RSIl3AQdOFQysIwJP9nlYsSFeaUznVIXfbYwLA=";
     subPackages = [ "." ];
 
     meta = with lib; {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           version = "1.0.0";
 
           src = ./.;
-          vendorSha256 = "sha256-Ezt1HDxGQ7DePF90HgHKkH7v365ICFdnfcWJipLhCwQ=";
+          vendorHash = "sha256-Ezt1HDxGQ7DePF90HgHKkH7v365ICFdnfcWJipLhCwQ=";
 
           meta = with pkgs.lib; {
             description = "Relay prometheus alerts to ntfy";

--- a/module.nix
+++ b/module.nix
@@ -2,10 +2,10 @@
 with lib;
 
 # with lib;
-let cfg = config.pinpox.services.alertmanager-ntfy;
+let cfg = config.services.alertmanager-ntfy;
 in {
 
-  options.pinpox.services.alertmanager-ntfy = {
+  options.services.alertmanager-ntfy = {
     enable = mkEnableOption "alertmanager-ntfy service";
 
     httpAddress = mkOption {


### PR DESCRIPTION
Changes:
* Fixed deprecation warning
* Works now with what's in the readme instead of something else
* Make it be actually under `services.alertmanager-ntfy`