### PR TITLE
allow empty username in case of access tokens in Basic Auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,9 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 		req.Header.Set("Tags", strings.Join(maps.Values(alert.Labels), ","))
 
 		username, password := os.Getenv("NTFY_USER"), os.Getenv("NTFY_PASS")
-		if username != "" && password != "" {
+		// allow empty `username` (access tokens in Basic Auth leave username empty)
+		// <https://docs.ntfy.sh/publish/#access-tokens>
+		if password != "" {
 			req.SetBasicAuth(username, password)
 		}
 


### PR DESCRIPTION
This is a very small change to allow `NTFY_USER` to be empty.

I found this is needed when using access tokens with Basic Auth, where the username is empty and password is the token.
https://docs.ntfy.sh/publish/#access-tokens

