### PR TITLE
Validate ntfy.sh URL before use

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -42,7 +43,7 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 		req, err := http.NewRequest("POST", os.Getenv("NTFY_TOPIC"), strings.NewReader(alert.Annotations["description"]))
 		if err != nil {
-			log.Printf("Building request to %s failed: %s", req.RemoteAddr, err)
+			log.Printf("Building request failed: %s", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -88,6 +89,11 @@ func main() {
 		if len(strings.TrimSpace(os.Getenv(v))) == 0 {
 			panic("Environment variable " + v + " not set!")
 		}
+	}
+
+	_, err := url.Parse(os.Getenv("NTFY_TOPIC"))
+	if err != nil {
+		log.Fatal("Environment variable NTFY_TOPIC is not a valid URL")
 	}
 
 	http.HandleFunc("/", WebhookHandler)


### PR DESCRIPTION
I had a couple of panics due to invalid URL, which could have been an error message during startup.

Example:

    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: 2024/04/01 17:33:49 Received valid hook from 127.0.0.1:43130
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: 2024/04/01 17:33:49 Processing alert: {firing map[alertname:Target Down instance:devkit.local:80 job:esphome severity:high] map[description:The target is not reachable summary:Target is down] 2024->
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: 2024/04/01 17:33:49 http: panic serving 127.0.0.1:43130: runtime error: invalid memory address or nil pointer dereference
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: goroutine 1013 [running]:
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: net/http.(*conn).serve.func1()
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/net/http/server.go:1868 +0xb9
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: panic({0x840200?, 0xd01360?})
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/runtime/panic.go:920 +0x270
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: main.WebhookHandler({0xa1d5f0, 0xc00038e000}, 0xc0001b0000)
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /home/j/src/alertmanager-ntfy/main.go:45 +0xbf2
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: net/http.HandlerFunc.ServeHTTP(0x10?, {0xa1d5f0?, 0xc00038e000?}, 0xc0004020ac?)
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/net/http/server.go:2136 +0x29
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: net/http.(*ServeMux).ServeHTTP(0x411f45?, {0xa1d5f0, 0xc00038e000}, 0xc0001b0000)
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/net/http/server.go:2514 +0x142
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: net/http.serverHandler.ServeHTTP({0xa1c0c0?}, {0xa1d5f0?, 0xc00038e000?}, 0x6?)
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/net/http/server.go:2938 +0x8e
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: net/http.(*conn).serve(0xc0000d21b0, {0xa1e1f0, 0xc00027a600})
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/net/http/server.go:2009 +0x5f4
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]: created by net/http.(*Server).Serve in goroutine 1
    Apr 01 17:33:49 nyx.jabid.in alertmanager-ntfy[878013]:         /usr/lib/go/src/net/http/server.go:3086 +0x5cb