### PR TITLE
rename pkgs.system to pkgs.stdenv.hostPlatform.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       # defined overlays injected by the nixflake
       nixpkgs.overlays = [
         (_self: _super: {
-          alertmanager-ntfy = self.packages.${pkgs.system}.alertmanager-ntfy;
+          alertmanager-ntfy = self.packages.${pkgs.stdenv.hostPlatform.system}.alertmanager-ntfy;
         })
       ];
     });


### PR DESCRIPTION
Follows the recommended fix for the deprecation warning.

From the [nixpkgs commit](https://github.com/NixOS/nixpkgs/commit/90cb7876446bf1684ffe40ab7832de0ec1b92991)  adding the warning, it looks like `stdenv.hostPlatform.system` was added in year 2021, so hopefully this is a fairly backwards-compatible change?
